### PR TITLE
feat: Revert from Uploadcare to Google Drive for file uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
     <!-- Leaflet CSS for Map -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 
-    <!-- Uploadcare Widget -->
-    <script src="https://ucarecdn.com/libs/widget/3.x/uploadcare.full.min.js" charset="utf-8"></script>
-
     <style>
         /* Custom styles combining both designs */
         :root {
@@ -260,14 +257,10 @@
                 <div class="w-20 h-1 bg-gradient-to-r from-[var(--peach)] to-[var(--emerald)] mx-auto mb-12 reveal"></div>
                 <p class="max-w-2xl mx-auto mb-8 text-lg reveal">Help us capture every special moment! Please upload your photos and videos from our wedding day. Large images will be automatically resized to ensure a smooth upload.</p>
                 <div class="reveal max-w-lg mx-auto">
-                    <input type="hidden" role="uploadcare-uploader"
-                           data-public-key="24c0c3526246451b3eac"
-                           data-multiple="true"
-                           data-multiple-max="20"
-                           data-image-shrink="2048x2048"
-                           data-tabs="file camera url facebook gdrive dropbox instagram"
-                           data-effects="crop,rotate,mirror,flip,enhance,grayscale,sharp"
-                           />
+                    <a href="https://drive.google.com/drive/folders/11eQ_NoE4tIAywloW8Rk-dVatgipsexTR?usp=sharing" target="_blank" class="bg-[var(--emerald)] text-white font-bold py-4 px-8 rounded-full hover:bg-green-600 transition-colors shadow-lg inline-flex items-center gap-3 text-xl">
+                        <i class="fas fa-camera"></i>
+                        Upload Photos & Videos
+                    </a>
                 </div>
             </div>
         </section>
@@ -572,9 +565,8 @@
             // --- CTA UPLOAD BUTTON ---
             const ctaUploadButton = document.getElementById('cta-upload-button');
             if (ctaUploadButton) {
-                const widget = uploadcare.Widget('[role=uploadcare-uploader]');
                 ctaUploadButton.addEventListener('click', () => {
-                    widget.openDialog();
+                    window.open('https://drive.google.com/drive/folders/11eQ_NoE4tIAywloW8Rk-dVatgipsexTR?usp=sharing', '_blank');
                 });
             }
 


### PR DESCRIPTION
- Removed Uploadcare widget script and input from index.html.
- Replaced the file uploader with a button linking to a shared Google Drive folder.
- Updated the floating CTA button to open the Google Drive link in a new tab.